### PR TITLE
Proxy detection

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -37,3 +37,20 @@ pub static SIMULATOR_CODE: Lazy<Bytes> = Lazy::new(|| {
         .parse()
         .unwrap()
 });
+
+// adapted from: https://github.com/gnosis/evm-proxy-detection/blob/main/src/index.ts
+pub static EIP_1967_LOGIC_SLOT: &str =
+    "0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc";
+pub static EIP_1967_BEACON_SLOT: &str =
+    "0xa3f0ad74e5423aebfd80d3ef4346578335a9a72aeaee59ff6cb3582b35133d50";
+pub static OPEN_ZEPPELIN_IMPLEMENTATION_SLOT: &str =
+    "0x7050c9e0f4ca769c69bd3a8ef740bc37934f8e2c036e5a723fd8ee048ed3f8c3";
+pub static EIP_1882_LOGIC_SLOT: &str =
+    "0xc5f16f0fcc639fa48a6947836d9850f504798523bf8c9a3a87d5876cf622bcf7";
+
+pub static IMPLEMENTATION_SLOTS: Lazy<Vec<U256>> = Lazy::new(|| {vec![
+    U256::from(EIP_1967_LOGIC_SLOT),
+    U256::from(EIP_1967_BEACON_SLOT),
+    U256::from(OPEN_ZEPPELIN_IMPLEMENTATION_SLOT),
+    U256::from(EIP_1882_LOGIC_SLOT),
+]});

--- a/src/honeypot.rs
+++ b/src/honeypot.rs
@@ -1,3 +1,4 @@
+use alloy_primitives::{Address, U160};
 use ethers::types::{Block, BlockId, BlockNumber, H160, H256, U256, U64};
 use ethers_providers::Middleware;
 use log::info;
@@ -173,6 +174,16 @@ impl<M: Middleware + 'static> HoneypotFilter<M> {
                     // skip if test_tokens was already tested
                     continue;
                 }
+
+                // Check if the token contract is proxy
+                // If it's proxy contract, we put that into invalid token list without any additional validations
+                // NOTE: use big endian to convert H160 bytes into U160
+                let is_proxy_contr = self.simulator.is_proxy(Address::from(U160::from_be_bytes(test_token.0)));
+                if is_proxy_contr {
+                    info!("⚠️ [{}] {} is proxy", idx, test_token);
+                    self.honeypot.insert(test_token, true);
+                    continue;
+                }    
 
                 // We take extra measures to filter out the pools with too little liquidity
                 // Using the below amount to test swaps, we know that there's enough liquidity in the pool

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+use alloy_primitives::{Address, U160};
 use anyhow::Result;
 use cfmms::dex::DexVariant;
 use ethers::providers::{Middleware, Provider, Ws};

--- a/src/simulator.rs
+++ b/src/simulator.rs
@@ -1,8 +1,8 @@
-use alloy_primitives::B256;
+use alloy_primitives::{B256, Address};
 use anyhow::{anyhow, Result};
 use bytes::Bytes;
 use ethers::abi;
-use ethers::types::{Transaction, H160, U256, U64};
+use ethers::types::{Transaction, H160, U256, U64,};
 use ethers_providers::Middleware;
 use foundry_evm::{
     fork::{BlockchainDb, BlockchainDbMeta, SharedBackend},
@@ -16,9 +16,10 @@ use foundry_evm::{
     },
 };
 use foundry_utils::types::{ToAlloy, ToEthers};
+// use hex::FromHex;
 use std::{collections::BTreeSet, str::FromStr, sync::Arc};
 
-use crate::constants::SIMULATOR_CODE;
+use crate::constants::{SIMULATOR_CODE, IMPLEMENTATION_SLOTS};
 use crate::interfaces::{pool::V2PoolABI, simulator::SimulatorABI, token::TokenABI};
 
 #[derive(Clone)]
@@ -362,5 +363,26 @@ impl<M: Middleware + 'static> EvmSimulator<M> {
         })?;
         let out = self.simulator.get_amount_out_output(value.output)?;
         Ok(out)
+    }
+
+    pub fn is_proxy(
+        &mut self,
+        token: Address,
+    ) -> bool {
+        let mut is_proxy = false;
+               
+        for slot in IMPLEMENTATION_SLOTS.iter() {
+            let impl_addr = self
+                .evm
+                .db
+                .as_mut()
+                .unwrap()
+                .storage(token, slot.to_alloy()).unwrap();
+            if impl_addr.count_zeros() != 256 {
+                is_proxy = true;
+            }
+        }
+    
+        is_proxy
     }
 }

--- a/src/simulator.rs
+++ b/src/simulator.rs
@@ -2,7 +2,7 @@ use alloy_primitives::{B256, Address};
 use anyhow::{anyhow, Result};
 use bytes::Bytes;
 use ethers::abi;
-use ethers::types::{Transaction, H160, U256, U64,};
+use ethers::types::{Transaction, H160, U256, U64};
 use ethers_providers::Middleware;
 use foundry_evm::{
     fork::{BlockchainDb, BlockchainDbMeta, SharedBackend},

--- a/src/simulator.rs
+++ b/src/simulator.rs
@@ -16,7 +16,6 @@ use foundry_evm::{
     },
 };
 use foundry_utils::types::{ToAlloy, ToEthers};
-// use hex::FromHex;
 use std::{collections::BTreeSet, str::FromStr, sync::Arc};
 
 use crate::constants::{SIMULATOR_CODE, IMPLEMENTATION_SLOTS};

--- a/src/tokens.rs
+++ b/src/tokens.rs
@@ -6,7 +6,7 @@ use ethers_core::types::{BlockId, BlockNumber, TxHash, H160, U256};
 use std::{str::FromStr, sync::Arc};
 use tokio::task::JoinSet;
 
-use crate::constants::ZERO_ADDRESS;
+use crate::constants::{ZERO_ADDRESS, IMPLEMENTATION_SLOTS};
 
 #[derive(Debug, Clone)]
 pub struct Token {
@@ -59,32 +59,32 @@ pub async fn get_implementation<M: Middleware + 'static>(
     token: H160,
     block_number: U64,
 ) -> Result<Option<H160>> {
-    // adapted from: https://github.com/gnosis/evm-proxy-detection/blob/main/src/index.ts
-    let eip_1967_logic_slot =
-        U256::from("0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc");
-    let eip_1967_beacon_slot =
-        U256::from("0xa3f0ad74e5423aebfd80d3ef4346578335a9a72aeaee59ff6cb3582b35133d50");
-    let open_zeppelin_implementation_slot =
-        U256::from("0x7050c9e0f4ca769c69bd3a8ef740bc37934f8e2c036e5a723fd8ee048ed3f8c3");
-    let eip_1822_logic_slot =
-        U256::from("0xc5f16f0fcc639fa48a6947836d9850f504798523bf8c9a3a87d5876cf622bcf7");
+    // // adapted from: https://github.com/gnosis/evm-proxy-detection/blob/main/src/index.ts
+    // let eip_1967_logic_slot =
+    //     U256::from("0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc");
+    // let eip_1967_beacon_slot =
+    //     U256::from("0xa3f0ad74e5423aebfd80d3ef4346578335a9a72aeaee59ff6cb3582b35133d50");
+    // let open_zeppelin_implementation_slot =
+    //     U256::from("0x7050c9e0f4ca769c69bd3a8ef740bc37934f8e2c036e5a723fd8ee048ed3f8c3");
+    // let eip_1822_logic_slot =
+    //     U256::from("0xc5f16f0fcc639fa48a6947836d9850f504798523bf8c9a3a87d5876cf622bcf7");
 
-    let implementation_slots = vec![
-        eip_1967_logic_slot,
-        eip_1967_beacon_slot,
-        open_zeppelin_implementation_slot,
-        eip_1822_logic_slot,
-    ];
+    // let implementation_slots = vec![
+    //     eip_1967_logic_slot,
+    //     eip_1967_beacon_slot,
+    //     open_zeppelin_implementation_slot,
+    //     eip_1822_logic_slot,
+    // ];
 
     let mut set = JoinSet::new();
 
-    for slot in implementation_slots {
+    for slot in IMPLEMENTATION_SLOTS.iter() {
         let _provider = provider.clone();
         let fut = tokio::spawn(async move {
             _provider
                 .get_storage_at(
                     token,
-                    TxHash::from_uint(&slot),
+                    TxHash::from_uint(slot),
                     Some(BlockId::Number(BlockNumber::Number(block_number))),
                 )
                 .await

--- a/src/tokens.rs
+++ b/src/tokens.rs
@@ -59,23 +59,6 @@ pub async fn get_implementation<M: Middleware + 'static>(
     token: H160,
     block_number: U64,
 ) -> Result<Option<H160>> {
-    // // adapted from: https://github.com/gnosis/evm-proxy-detection/blob/main/src/index.ts
-    // let eip_1967_logic_slot =
-    //     U256::from("0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc");
-    // let eip_1967_beacon_slot =
-    //     U256::from("0xa3f0ad74e5423aebfd80d3ef4346578335a9a72aeaee59ff6cb3582b35133d50");
-    // let open_zeppelin_implementation_slot =
-    //     U256::from("0x7050c9e0f4ca769c69bd3a8ef740bc37934f8e2c036e5a723fd8ee048ed3f8c3");
-    // let eip_1822_logic_slot =
-    //     U256::from("0xc5f16f0fcc639fa48a6947836d9850f504798523bf8c9a3a87d5876cf622bcf7");
-
-    // let implementation_slots = vec![
-    //     eip_1967_logic_slot,
-    //     eip_1967_beacon_slot,
-    //     open_zeppelin_implementation_slot,
-    //     eip_1822_logic_slot,
-    // ];
-
     let mut set = JoinSet::new();
 
     for slot in IMPLEMENTATION_SLOTS.iter() {


### PR DESCRIPTION
In this branch, I implemented a validation to detect if the contract is proxy or not.

It detects the following proxy patterns:
- eip 1967 ( '0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc')
- eip 1967 beacon ( '0xa3f0ad74e5423aebfd80d3ef4346578335a9a72aeaee59ff6cb3582b35133d50')
- open zeppelin implementation ('0x7050c9e0f4ca769c69bd3a8ef740bc37934f8e2c036e5a723fd8ee048ed3f8c3')
- eip 1882 (`0xc5f16f0fcc639fa48a6947836d9850f504798523bf8c9a3a87d5876cf622bcf7`)

The reason why these patterns are chosen are the custom that almost all proxy contract for ERC20 follows above.