### PR TITLE
deps: Pin `alloy-rs` and `foundry-compiles` version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,7 +90,7 @@ dependencies = [
 [[package]]
 name = "alloy-dyn-abi"
 version = "0.4.2"
-source = "git+https://github.com/alloy-rs/core/#2809e8b3688f9959c32141d3b99d66ee7899ba38"
+source = "git+https://github.com/alloy-rs/core/?rev=a707bcd7cd3979532296d9a8fc441b836f9c7168#a707bcd7cd3979532296d9a8fc441b836f9c7168"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -110,7 +110,7 @@ dependencies = [
 [[package]]
 name = "alloy-json-abi"
 version = "0.4.2"
-source = "git+https://github.com/alloy-rs/core/#2809e8b3688f9959c32141d3b99d66ee7899ba38"
+source = "git+https://github.com/alloy-rs/core/?rev=a707bcd7cd3979532296d9a8fc441b836f9c7168#a707bcd7cd3979532296d9a8fc441b836f9c7168"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-type-parser",
@@ -121,7 +121,7 @@ dependencies = [
 [[package]]
 name = "alloy-primitives"
 version = "0.4.2"
-source = "git+https://github.com/alloy-rs/core/#2809e8b3688f9959c32141d3b99d66ee7899ba38"
+source = "git+https://github.com/alloy-rs/core/?rev=a707bcd7cd3979532296d9a8fc441b836f9c7168#a707bcd7cd3979532296d9a8fc441b836f9c7168"
 dependencies = [
  "alloy-rlp",
  "arbitrary",
@@ -168,7 +168,7 @@ dependencies = [
 [[package]]
 name = "alloy-sol-macro"
 version = "0.4.2"
-source = "git+https://github.com/alloy-rs/core/#2809e8b3688f9959c32141d3b99d66ee7899ba38"
+source = "git+https://github.com/alloy-rs/core/?rev=a707bcd7cd3979532296d9a8fc441b836f9c7168#a707bcd7cd3979532296d9a8fc441b836f9c7168"
 dependencies = [
  "const-hex",
  "dunce",
@@ -185,7 +185,7 @@ dependencies = [
 [[package]]
 name = "alloy-sol-type-parser"
 version = "0.4.2"
-source = "git+https://github.com/alloy-rs/core/#2809e8b3688f9959c32141d3b99d66ee7899ba38"
+source = "git+https://github.com/alloy-rs/core/?rev=a707bcd7cd3979532296d9a8fc441b836f9c7168#a707bcd7cd3979532296d9a8fc441b836f9c7168"
 dependencies = [
  "winnow",
 ]
@@ -193,7 +193,7 @@ dependencies = [
 [[package]]
 name = "alloy-sol-types"
 version = "0.4.2"
-source = "git+https://github.com/alloy-rs/core/#2809e8b3688f9959c32141d3b99d66ee7899ba38"
+source = "git+https://github.com/alloy-rs/core/?rev=a707bcd7cd3979532296d9a8fc441b836f9c7168#a707bcd7cd3979532296d9a8fc441b836f9c7168"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-macro",
@@ -1371,9 +1371,9 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2e66c9d817f1720209181c316d28635c050fa304f9c79e47a520882661b7308"
+checksum = "7e962a19be5cfc3f3bf6dd8f61eb50107f356ad6270fbb3ed41476571db78be5"
 
 [[package]]
 name = "der"
@@ -2219,9 +2219,9 @@ dependencies = [
 
 [[package]]
 name = "form_urlencoded"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a62bc1cf6f830c2ec14a513a9fb124d0a213a629668a4186f329db21fe045652"
+checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
 ]
@@ -2337,8 +2337,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dcfb3af0dd69f2989ab2311f2c97fdd470227d3c9f657be04092572a3a1db60"
+source = "git+https://github.com/foundry-rs/compilers?rev=816184ad7a47996f3382dc73dc52566fb12fb3df#816184ad7a47996f3382dc73dc52566fb12fb3df"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -3040,9 +3039,9 @@ dependencies = [
 
 [[package]]
 name = "idna"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
+checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
 dependencies = [
  "unicode-bidi",
  "unicode-normalization",
@@ -3729,9 +3728,9 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.59"
+version = "0.10.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a257ad03cd8fb16ad4172fedf8094451e1af1c4b70097636ef2eac9a5f0cc33"
+checksum = "79a4c6c3a2b158f7f8f2a2fc5a969fa3a068df6fc9dbb4a43845436e3af7c800"
 dependencies = [
  "bitflags 2.4.1",
  "cfg-if",
@@ -3761,9 +3760,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.95"
+version = "0.9.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40a4130519a360279579c2053038317e40eff64d13fd3f004f9e1b72b8a6aaf9"
+checksum = "3812c071ba60da8b5677cc12bcb1d42989a65553772897a7e0355545a819838f"
 dependencies = [
  "cc",
  "libc",
@@ -3991,9 +3990,9 @@ dependencies = [
 
 [[package]]
 name = "percent-encoding"
-version = "2.3.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
+checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pest"
@@ -5352,7 +5351,7 @@ dependencies = [
 [[package]]
 name = "syn-solidity"
 version = "0.4.2"
-source = "git+https://github.com/alloy-rs/core/#2809e8b3688f9959c32141d3b99d66ee7899ba38"
+source = "git+https://github.com/alloy-rs/core/?rev=a707bcd7cd3979532296d9a8fc441b836f9c7168#a707bcd7cd3979532296d9a8fc441b836f9c7168"
 dependencies = [
  "paste",
  "proc-macro2",
@@ -5968,9 +5967,9 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "143b538f18257fac9cad154828a57c6bf5157e1aa604d4816b5995bf6de87ae5"
+checksum = "31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -6147,9 +6146,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.25.2"
+version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14247bb57be4f377dfb94c72830b8ce8fc6beac03cf4bf7b9732eadd414123fc"
+checksum = "1778a42e8b3b90bff8d0f5032bf22250792889a5cdc752aa0020c84abe3aaf10"
 
 [[package]]
 name = "which"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,10 +52,12 @@ ethers-middleware = { git = "https://github.com/gakonst/ethers-rs", rev = "4e09b
 ethers-etherscan = { git = "https://github.com/gakonst/ethers-rs", rev = "4e09be88730045dd6c4ed8a4e198a9956931e7bd" }
 ethers-solc = { git = "https://github.com/gakonst/ethers-rs", rev = "4e09be88730045dd6c4ed8a4e198a9956931e7bd" }
 
-alloy-dyn-abi = { git = "https://github.com/alloy-rs/core/" }
-alloy-primitives = { git = "https://github.com/alloy-rs/core/" }
-alloy-json-abi = { git = "https://github.com/alloy-rs/core/" }
-alloy-sol-types = { git = "https://github.com/alloy-rs/core/" }
+alloy-dyn-abi = { git = "https://github.com/alloy-rs/core/", rev = "a707bcd7cd3979532296d9a8fc441b836f9c7168" }
+alloy-primitives = { git = "https://github.com/alloy-rs/core/", rev = "a707bcd7cd3979532296d9a8fc441b836f9c7168" }
+alloy-json-abi = { git = "https://github.com/alloy-rs/core/", rev = "a707bcd7cd3979532296d9a8fc441b836f9c7168" }
+alloy-sol-types = { git = "https://github.com/alloy-rs/core/", rev = "a707bcd7cd3979532296d9a8fc441b836f9c7168" }
+
+foundry-compilers = { git = "https://github.com/foundry-rs/compilers", rev = "816184ad7a47996f3382dc73dc52566fb12fb3df" }
 
 revm = { git = "https://github.com/bluealloy/revm", rev = "1609e07c68048909ad1682c98cf2b9baa76310b5" }
 revm-primitives = { git = "https://github.com/bluealloy/revm", rev = "1609e07c68048909ad1682c98cf2b9baa76310b5" }


### PR DESCRIPTION
To ensure that a build can be done under a specific version