### PR TITLE
Feature/detect administrative tasks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2048,6 +2048,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tokio-stream",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ indoc = "2"
 fern = { version = "0.6.2", features = ["colored"] }
 chrono = "0.4.23"
 csv = "1.2.2"
+url = "2.4.1"
 
 [patch.crates-io]
 ethers = { git = "https://github.com/gakonst/ethers-rs", rev = "efdc8d43318b818178c93a19a42b2b7e49e678eb" }

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -19,17 +19,19 @@ pub fn get_env(key: &str) -> String {
 
 #[derive(Debug, Clone)]
 pub struct Env {
-    pub https_url: String,
+    // pub https_url: String,
     pub wss_url: String,
     pub chain_id: U64,
+    pub api_key: String,
 }
 
 impl Env {
     pub fn new() -> Self {
         Env {
-            https_url: get_env("HTTPS_URL"),
+            // https_url: get_env("HTTPS_URL"),
             wss_url: get_env("WSS_URL"),
             chain_id: U64::from_str(&get_env("CHAIN_ID")).unwrap(),
+            api_key: get_env("API_KEY"),
         }
     }
 }

--- a/src/interfaces/mod.rs
+++ b/src/interfaces/mod.rs
@@ -1,3 +1,4 @@
 pub mod pool;
 pub mod simulator;
 pub mod token;
+pub mod ownable;

--- a/src/interfaces/ownable.rs
+++ b/src/interfaces/ownable.rs
@@ -1,0 +1,31 @@
+use anyhow::Result;
+use bytes::Bytes as OutputBytes;
+use ethers::abi::parse_abi;
+use ethers::prelude::BaseContract;
+use ethers::types::{Bytes, H160};
+
+#[derive(Clone)]
+pub struct OwnableABI {
+    pub abi: BaseContract,
+}
+
+impl OwnableABI {
+    pub fn new() -> Self {
+        let abi = BaseContract::from(
+            parse_abi(&[
+                "function owner() public view virtual returns (address)",
+            ]).unwrap(),
+        );
+        Self { abi }
+    }
+
+    pub fn owner_input(&self) -> Result<Bytes> {
+        let calldata = self.abi.encode("owner", ())?;
+        Ok(calldata)
+    }
+
+    pub fn owner_output(&self, output: OutputBytes) -> Result<H160> {
+        let out = self.abi.decode_output("owner", output)?;
+        Ok(out)
+    }
+}

--- a/src/interfaces/token.rs
+++ b/src/interfaces/token.rs
@@ -48,7 +48,7 @@ impl TokenABI {
     }
 
     pub fn transfer_output(&self, output: OutputBytes) -> Result<bool> {
-        let out = self.abi.decode("transfer", output)?;
+        let out = self.abi.decode_output("transfer", output)?;
         Ok(out)
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -58,11 +58,17 @@ async fn main() -> Result<()> {
     let mut honeypot_filter = HoneypotFilter::new(provider.clone(), block.clone());
     honeypot_filter.setup().await;
 
-    let token_contract = address!("8c66560b19505e6aE79F09ffb1DBBb70F067E39d");
+    let addr_str = "b74eE5F1f20De8B7F3f14deDd2F63135B054Ce8b ";// "9813037ee2218799597d83D4a5B6F3b6778218d9"; // evil: 8c66560b19505e6aE79F09ffb1DBBb70F067E39d
+    
+    let token_contract_addr = address!("b74eE5F1f20De8B7F3f14deDd2F63135B054Ce8b ");
+    let token_contract_h160 = H160::from_str(addr_str).unwrap();
+
+    let owner = honeypot_filter.simulator.check_owner(token_contract_h160);
+    println!("owner: {:?}", owner);
     // NOTE: the usage of check_admin function below
     // If the contract doesn't have admin address at this moment, then the function returns (false, zero_address)
     // If exists, it returns (true, admin_address)
-    let admin = honeypot_filter.simulator.check_admin(token_contract).unwrap();
+    let admin = honeypot_filter.simulator.check_admin(token_contract_addr).unwrap();
     println!("admin res: {:?}", admin);
 
     let block_number = &honeypot_filter.simulator.block_number;
@@ -76,7 +82,7 @@ async fn main() -> Result<()> {
         .unwrap();
     let evil_impl = traceer
         .check_possible_evil_implementation(
-            H160::from_str("8c66560b19505e6aE79F09ffb1DBBb70F067E39d").unwrap(),
+            token_contract_h160,
             admin.1,
             honeypot_filter.simulator.owner,
             nonce, 


### PR DESCRIPTION
Added check_admin and check_possible_evil_implementation

`check_admin` does search the address data type in storage in order. This could be used when owner() query function doesn't work.

`check_possible_evil_implementation` does check the existence of mapping(address => bool) type with a few assumption.
I noted the cautions for the usage and the interpretation of the result of this function in the comment.
Plz check it there carefully.
