### PR TITLE
detect admin

### DIFF
--- a/src/interfaces/mod.rs
+++ b/src/interfaces/mod.rs
@@ -1,3 +1,4 @@
+pub mod ownable;
 pub mod pool;
 pub mod simulator;
 pub mod token;

--- a/src/interfaces/ownable.rs
+++ b/src/interfaces/ownable.rs
@@ -12,9 +12,7 @@ pub struct OwnableABI {
 impl OwnableABI {
     pub fn new() -> Self {
         let abi = BaseContract::from(
-            parse_abi(&[
-                "function owner() public view virtual returns (address)",
-            ]).unwrap(),
+            parse_abi(&["function owner() public view virtual returns (address)"]).unwrap(),
         );
         Self { abi }
     }

--- a/src/interfaces/ownable.rs
+++ b/src/interfaces/ownable.rs
@@ -1,0 +1,31 @@
+use anyhow::Result;
+use bytes::Bytes as OutputBytes;
+use ethers::abi::parse_abi;
+use ethers::prelude::BaseContract;
+use ethers::types::{Bytes, H160};
+
+#[derive(Clone)]
+pub struct OwnableABI {
+    pub abi: BaseContract,
+}
+
+impl OwnableABI {
+    pub fn new() -> Self {
+        let abi = BaseContract::from(
+            parse_abi(&[
+                "function owner() public view virtual returns (address)",
+            ]).unwrap(),
+        );
+        Self { abi }
+    }
+
+    pub fn owner_input(&self) -> Result<Bytes> {
+        let calldata = self.abi.encode("owner", ())?;
+        Ok(calldata)
+    }
+
+    pub fn owner_output(&self, output: OutputBytes) -> Result<H160> {
+        let out = self.abi.decode_output("owner", output)?;
+        Ok(out)
+    }
+}

--- a/src/simulator.rs
+++ b/src/simulator.rs
@@ -468,23 +468,15 @@ impl<M: Middleware + 'static> EvmSimulator<M> {
         let out = self.ownable.owner_output(value.output)?;
         Ok(out)
     }
-    
+
     // Check the existence of an admin address for ERC20 contract.
     // The reason why it is limited to ERC20 contract is because we assume the specific storage slot management.
     // In ERC20, the standard implementation and the plugin parts are highly limited. Hence, we assume if the ERC20 contract
     // has address type storage slot in the contract, it would be the address who can do administrative tasks as an admin.
-    pub fn check_admin(
-        &mut self,
-        token_contract: Address,
-    ) -> Result<(bool, Vec<H160>)> {
+    pub fn check_admin(&mut self, token_contract: Address) -> Result<(bool, Vec<H160>)> {
         let mut possible_admins = Vec::new();
         for i in 0..15 {
-            let res = self
-            .evm
-            .db
-            .as_mut()
-            .unwrap()
-            .storage(token_contract, aU256::from(i))?;
+            let res = self.evm.db.as_mut().unwrap().storage(token_contract, aU256::from(i))?;
 
             // Convert Uint<256, 4> to big-endian bytes and take the values from 12 to the last
             let mut be_vec = res.as_le_slice().to_vec();
@@ -498,7 +490,7 @@ impl<M: Middleware + 'static> EvmSimulator<M> {
             if !owner.is_zero() {
                 possible_admins.push(owner);
             }
-        }   
+        }
 
         let possible_address_storage = !possible_admins.is_empty();
         Ok((possible_address_storage, possible_admins))

--- a/src/simulator.rs
+++ b/src/simulator.rs
@@ -19,6 +19,7 @@ use foundry_utils::types::{ToAlloy, ToEthers};
 use std::{collections::BTreeSet, str::FromStr, sync::Arc};
 
 use crate::constants::{IMPLEMENTATION_SLOTS, SIMULATOR_CODE};
+use crate::interfaces::ownable::OwnableABI;
 use crate::interfaces::{pool::V2PoolABI, simulator::SimulatorABI, token::TokenABI};
 use crate::tokens::get_token_info;
 use crate::trace::EvmTracer;
@@ -33,6 +34,7 @@ pub struct EvmSimulator<M> {
     pub token: TokenABI,
     pub v2_pool: V2PoolABI,
     pub simulator: SimulatorABI,
+    pub ownable: OwnableABI,
 
     pub simulator_address: H160,
 }
@@ -94,6 +96,7 @@ impl<M: Middleware + 'static> EvmSimulator<M> {
             token: TokenABI::new(),
             v2_pool: V2PoolABI::new(),
             simulator: SimulatorABI::new(),
+            ownable: OwnableABI::new(),
 
             simulator_address: H160::from_str("0x4E17607Fb72C01C280d7b5c41Ba9A2109D74a32C")
                 .unwrap(),
@@ -433,6 +436,7 @@ impl<M: Middleware + 'static> EvmSimulator<M> {
             value: U256::zero(),
             gas_limit: 5000000,
         };
+
         let value = if commit { self.call(tx)? } else { self.staticcall(tx)? };
 
         let out = self.simulator.simple_transfer_output(value.output)?;
@@ -442,5 +446,26 @@ impl<M: Middleware + 'static> EvmSimulator<M> {
             return_amount: out.1,
             gas_used: value.gas_used,
         })
+    }
+
+    // It calls owner() view function in the format of Ownable interface from OpenZeppelin
+    // You can interpret the result as follows:
+    // If the result is Address, but not zero, then, it is the address stored as owner for Ownable part
+    // It it's Zero Address, it means the former owner called renounce to throw away the ownership
+    // If the result if Err and the execution is reverted, the token_contract doesn't inherit the Ownable
+    pub fn check_owner(&mut self, token_contract: H160) -> Result<H160> {
+        let calldata = self.ownable.owner_input()?;
+
+        let tx = Tx {
+            caller: self.owner,
+            transact_to: token_contract,
+            data: calldata.0,
+            value: U256::zero(),
+            gas_limit: 5000000,
+        };
+
+        let value = self.staticcall(tx)?;
+        let out = self.ownable.owner_output(value.output)?;
+        Ok(out)
     }
 }


### PR DESCRIPTION
`check_admin` does search the address data type in storage in order. This could be used when owner() query function doesn't work.